### PR TITLE
feat: 브리지 로직 구현

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -35,7 +35,15 @@ const eslintConfig = [
     rules: {
       // 강력하게 설정된 규칙들
       "no-console": ["error", { allow: ["warn", "error"] }],
-      "no-unused-vars": "error",
+      "no-unused-vars": [
+        "error",
+        {
+          varsIgnorePattern: "^_",
+          argsIgnorePattern: "^_",
+          ignoreRestSiblings: true,
+          args: "none", // 함수 파라미터 체크 비활성화
+        },
+      ],
       "prefer-const": "error",
       "no-var": "error", // var 사용 금지
 

--- a/src/components/common/entities/Bridge/index.tsx
+++ b/src/components/common/entities/Bridge/index.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useLayoutEffect } from "react";
+
+declare global {
+  interface Window {
+    ReactNativeWebView?: {
+      postMessage(message: string): void;
+    };
+  }
+}
+
+export interface MessageEventResponseData<Data = unknown> {
+  status: "success" | "error";
+  name: string;
+  data?: Data;
+}
+
+export interface MessageEventRequestData<Body = unknown> {
+  method: "GET" | "POST" | "PUT" | "DELETE";
+  name: string;
+  body?: Body;
+}
+
+interface BridgeProps {
+  onRequest: (reqMessage: MessageEventRequestData) => MessageEventResponseData;
+}
+
+const Bridge = ({ onRequest }: BridgeProps) => {
+  useLayoutEffect(() => {
+    const handleMessage = ({ data }: MessageEvent) => {
+      const requestMessage = JSON.parse(data) as MessageEventRequestData;
+      const responseMessage = onRequest(requestMessage);
+      if (!responseMessage) return;
+      window.ReactNativeWebView?.postMessage(JSON.stringify(responseMessage));
+    };
+
+    window.addEventListener("message", handleMessage);
+
+    return () => window.removeEventListener("message", handleMessage);
+  }, [onRequest]);
+
+  return null;
+};
+
+export default Bridge;

--- a/src/hooks/useBridge/index.ts
+++ b/src/hooks/useBridge/index.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import {
+  MessageEventRequestData,
+  MessageEventResponseData,
+} from "@/components/common/entities/Bridge";
+import { useEffect } from "react";
+
+type EventHandler = (event: MessageEvent) => void;
+
+interface RequestProps<T> {
+  requestMessage: MessageEventRequestData;
+  responseCallback?: (resMessage: MessageEventResponseData<T>) => void;
+}
+
+const eventHandlers: EventHandler[] = [];
+
+export const useBridge = () => {
+  useEffect(() => {
+    return () => {
+      eventHandlers.forEach((handler) => {
+        window.removeEventListener("message", handler);
+      });
+      eventHandlers.length = 0;
+    };
+  }, []);
+
+  const request = <T>({
+    requestMessage,
+    responseCallback,
+  }: RequestProps<T>) => {
+    window.ReactNativeWebView?.postMessage(JSON.stringify(requestMessage));
+
+    const handler = (event: MessageEvent) => {
+      if (event.data.name !== requestMessage.name) return;
+      if (!responseCallback) return;
+      responseCallback(event.data);
+    };
+
+    eventHandlers.push(handler);
+
+    window.addEventListener("message", handler);
+  };
+
+  return { request };
+};


### PR DESCRIPTION
### 개요

close #10 

### 작업사항

앱와 웹의 통신 브리지 로직을 구현하였습니다. 

<Bridge/> 를 통해서 컨트롤러들을 구현할 수 있습니다. 
이 경우 onRequest를 통해서 구현하고자 하는 컨트롤러를 등록할 수 있습니다. 

useBridge() 를 통해서 앱으로 request할 수 있습니다. 
request시 자동으로 response가 

자세한 사항은 [브리지 문서]()를 확인해주세요.

테스트를 하고싶다면, `feat/10-bridge-library-test` 브랜치로 이동 후 앱을 실행하여 요청하면 됩니다.
해당 브랜치에 테스트를 해볼 수 있는 코드들이 존재합니다.

<details>
<summary>
동작 영상
</summary>

<div align="center">
<img width="25%" src="https://github.com/user-attachments/assets/5bf45f8d-709d-4ccb-94b2-c8f0780733f6"/>
</div>

</details>

### 리뷰어에게 

해당 로직이 DI 관점에서 괜찮은지 확인부탁드립니다. 