### PR TITLE
feat: 안전 매뉴얼 페이지 브리지 로직 추가

### DIFF
--- a/src/app/course/[mountainName]/page.tsx
+++ b/src/app/course/[mountainName]/page.tsx
@@ -3,6 +3,7 @@ import CourseTabSection from "@pages/course/CourseTabBarSection";
 import Spacing from "@shared/layout/Spacing";
 import BackButton from "@/components/features/widgets/BackButton";
 import Flex from "@/components/common/shared/layout/Flex";
+import { Suspense } from "react";
 
 export default function MountainCoursePage() {
   return (
@@ -15,7 +16,9 @@ export default function MountainCoursePage() {
           <Spacing size={4} />
         </div>
       </Flex>
-      <CourseTabSection />
+      <Suspense>
+        <CourseTabSection />
+      </Suspense>
     </Flex>
   );
 }

--- a/src/app/map/course-detail/page.tsx
+++ b/src/app/map/course-detail/page.tsx
@@ -5,6 +5,7 @@ import PositionBottom from "@shared/layout/PositionBottom";
 import Spacing from "@shared/layout/Spacing";
 import BackButton from "@widgets/BackButton";
 import TravelStartButton from "@widgets/TravelStartButton";
+import { Suspense } from "react";
 
 export default function CourseDetailPage() {
   return (
@@ -13,7 +14,9 @@ export default function CourseDetailPage() {
         <Spacing size={4} />
         <BackButton />
         <Spacing size={3} />
-        <CourseDetailMapTagHeaderSection />
+        <Suspense>
+          <CourseDetailMapTagHeaderSection />
+        </Suspense>
       </div>
       <PositionBottom bottom={88}>
         <div className="px-6">

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -2,6 +2,7 @@ import CourseDetailMapSection from "@pages/map/CourseDetailMapSection";
 import MapTadHeaderSection from "@pages/map/MapTadHeaderSection";
 import Spacing from "@shared/layout/Spacing";
 import BackButton from "@widgets/BackButton";
+import { Suspense } from "react";
 
 export default function MapPage() {
   return (
@@ -12,7 +13,9 @@ export default function MapPage() {
           <BackButton />
         </div>
         <Spacing size={3} />
-        <MapTadHeaderSection />
+        <Suspense>
+          <MapTadHeaderSection />
+        </Suspense>
       </div>
       <CourseDetailMapSection />
     </div>

--- a/src/app/safe-manual/detail/page.tsx
+++ b/src/app/safe-manual/detail/page.tsx
@@ -1,6 +1,7 @@
 import StackHeader from "@entities/StackHeader";
 import Spacing from "@shared/layout/Spacing";
 import SafeManualTab from "@widgets/SafeManualTab";
+import { Suspense } from "react";
 
 export default function SafeManualDetailPage() {
   return (
@@ -8,7 +9,9 @@ export default function SafeManualDetailPage() {
       <Spacing size={5} />
       <StackHeader title="안전 매뉴얼" />
       <Spacing size={5} />
-      <SafeManualTab />
+      <Suspense>
+        <SafeManualTab />
+      </Suspense>
     </div>
   );
 }

--- a/src/components/common/entities/Tabs/components/TabLIst/index.tsx
+++ b/src/components/common/entities/Tabs/components/TabLIst/index.tsx
@@ -1,5 +1,4 @@
 import { isValidElement, memo, useEffect } from "react";
-
 import useTabContext from "../../hooks/useTabContext";
 
 interface TabListProps {
@@ -17,8 +16,8 @@ export default memo(function TabList({ children }: TabListProps) {
   useEffect(() => {
     setTabItemsHandler(
       children.map((child) => {
-        if (isValidElement(child) && child.props?.label) {
-          return child.props.label;
+        if (isValidElement(child) && (child.props as any)?.label) {
+          return (child.props as any).label;
         }
         throw new Error(
           "TabList의 자식 요소는 유효한 React 요소여야 하며, label 속성을 가져야 합니다."

--- a/src/components/common/entities/Tabs/index.tsx
+++ b/src/components/common/entities/Tabs/index.tsx
@@ -8,9 +8,14 @@ import TabList from "./components/TabLIst/index";
 import TabContext from "./context/TabContext/index";
 import type { TabContextType } from "./types";
 
-// interface TabProps extends PropsWithChildren {}
+//TODO: 탭이 변경되면 상단으로 스크롤 되도록 구현하기
+//TODO: 탭이 변경되면 해당 탭 전체가 화면에 보이도록 탭 리스트 스크롤 되도록 구현하기
 
-export default function Tabs({ children }: PropsWithChildren) {
+interface TabProps extends PropsWithChildren {
+  onChange?: (selectedTab: string | null) => void;
+}
+
+export default function Tabs({ onChange, children }: TabProps) {
   const [tabItems, setTabItems] = useState<string[]>([]);
   const [selectedTab, setSelectedTab] = useState<string | null>(null);
   const [selectedTabIndex, setSelectedTabIndex] = useState<number | null>(null);
@@ -26,6 +31,12 @@ export default function Tabs({ children }: PropsWithChildren) {
   useEffect(() => {
     setSelectedTabIndex(tabItems.findIndex((item) => item === selectedTab));
   }, [selectedTab, setSelectedTabIndex, tabItems]);
+
+  useEffect(() => {
+    if (onChange) {
+      onChange(selectedTab);
+    }
+  }, [selectedTab, onChange]);
 
   const value: TabContextType = {
     tabItems,

--- a/src/components/features/pages/change-password/PasswordInfoSection/index.tsx
+++ b/src/components/features/pages/change-password/PasswordInfoSection/index.tsx
@@ -1,11 +1,10 @@
 "use client";
 
 import { usePasswordInfo } from "@hooks/feature/info/usePasswordInfo";
-import Cancel from "@icons/Cancel.svg";
 import Spacing from "@shared/layout/Spacing";
 import Button from "@shared/ui/Button";
+import CancelIcon from "@shared/ui/icons/CancelIcon";
 import TextField from "@shared/ui/TextField";
-import Image from "next/image";
 
 export default function PasswordInfoSection() {
   const { onChangePasswordInfo, onClearPasswordInfo, passwordInfo } =
@@ -23,7 +22,12 @@ export default function PasswordInfoSection() {
           onChange={(e) => onChangePasswordInfo("password", e.target.value)}
           right={
             <button onClick={() => onClearPasswordInfo("password")}>
-              <Image src={Cancel} alt="입력 취소" width={24} height={24} />
+              <CancelIcon
+                alt="입력 취소"
+                width={24}
+                height={24}
+                className="hidden"
+              />
             </button>
           }
         />
@@ -37,7 +41,12 @@ export default function PasswordInfoSection() {
           onChange={(e) => onChangePasswordInfo("newPassword", e.target.value)}
           right={
             <button onClick={() => onClearPasswordInfo("newPassword")}>
-              <Image src={Cancel} alt="입력 취소" width={24} height={24} />
+              <CancelIcon
+                alt="입력 취소"
+                width={24}
+                height={24}
+                className="hidden"
+              />
             </button>
           }
         />

--- a/src/components/features/pages/course/CourseTabBarSection/index.tsx
+++ b/src/components/features/pages/course/CourseTabBarSection/index.tsx
@@ -3,7 +3,7 @@
 import Spacing from "@/components/common/shared/layout/Spacing";
 import CourseMetaDataUi from "@/components/common/shared/ui/CourseMetaDataUi";
 import ROUTE from "@/constants/route";
-import useRouteCourseDetail from "@/hooks/bridge/useRouteCourseDetail";
+import useRouteBridge from "@/hooks/bridge/useRouteBridge";
 import { cn } from "@/utils/cn";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 
@@ -19,7 +19,10 @@ export default function CourseTabSection() {
   const { mountainName } = useParams<{ mountainName: string }>();
   const searchParams = useSearchParams();
   const sortBy = searchParams.get("sort");
-  const routeCourseDetail = useRouteCourseDetail();
+  const routeCourseDetail = useRouteBridge({
+    path: "course-detail",
+    routeType: "push",
+  });
 
   // TODO: 서버에서 데이터 받아오기
   const courseList = new Array(10).fill(0);

--- a/src/components/features/pages/safe-manual/ManualGridSection/index.tsx
+++ b/src/components/features/pages/safe-manual/ManualGridSection/index.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import useRouteBridge from "@/hooks/bridge/useRouteBridge";
 import ManualAnimalIcon from "@icons/ManualAnimalIcon";
 import ManualDistressIcon from "@icons/ManualDistressIcon";
 import ManualPainManIcon from "@icons/ManualPainManIcon";
@@ -5,9 +8,33 @@ import ManualTemperatureIcon from "@icons/ManualTemperatureIcon";
 import Spacing from "@shared/layout/Spacing";
 
 export default function ManualGridSection() {
+  const routeManualDetailInjury = useRouteBridge({
+    path: "manual-detail",
+    routeType: "push",
+    params: [{ manual: "신체 부상" }],
+  });
+  const routeManualDetailTemperature = useRouteBridge({
+    path: "manual-detail",
+    routeType: "push",
+    params: [{ manual: "체온 및 대사 이상" }],
+  });
+  const routeManualDetailAnimal = useRouteBridge({
+    path: "manual-detail",
+    routeType: "push",
+    params: [{ manual: "동물 및 자연환경 피해" }],
+  });
+  const routeManualDetailDistress = useRouteBridge({
+    path: "manual-detail",
+    routeType: "push",
+    params: [{ manual: "조난 및 고립" }],
+  });
+
   return (
     <div className="grid grid-cols-2 gap-4">
-      <div className="p-4 rounded-lg shadow break-keep">
+      <button
+        className="p-4 rounded-lg shadow break-keep"
+        onClick={routeManualDetailInjury}
+      >
         <span className="text-main-green font-bold text-lg text-center">
           신체 부상
         </span>
@@ -17,8 +44,11 @@ export default function ManualGridSection() {
         <p className="text-sm">
           외부 충격에 의한 일반적인 부상에 대한 응급조치
         </p>
-      </div>
-      <div className="p-4 rounded-lg shadow break-keep">
+      </button>
+      <button
+        className="p-4 rounded-lg shadow break-keep"
+        onClick={routeManualDetailTemperature}
+      >
         <span className="text-main-green font-bold text-lg text-center">
           체온 및 대사 이상
         </span>
@@ -31,8 +61,11 @@ export default function ManualGridSection() {
         <span className="text-sm leading-0">
           체온 저하 또는 탈수 등 체내 이상 징후 대응법
         </span>
-      </div>
-      <div className="p-4 rounded-lg shadow break-keep">
+      </button>
+      <button
+        className="p-4 rounded-lg shadow break-keep"
+        onClick={routeManualDetailAnimal}
+      >
         <span className="text-main-green font-bold text-lg text-center">
           동물 및 자연환경 피해
         </span>
@@ -45,8 +78,11 @@ export default function ManualGridSection() {
         <span className="text-sm leading-0">
           야생동물과 외부 환경에 의한 부상 대응
         </span>
-      </div>
-      <div className="p-4 rounded-lg shadow break-keep">
+      </button>
+      <button
+        className="p-4 rounded-lg shadow break-keep"
+        onClick={routeManualDetailDistress}
+      >
         <span className="text-main-green font-bold text-lg text-center">
           조난 및 고립
         </span>
@@ -59,7 +95,7 @@ export default function ManualGridSection() {
         <span className="text-sm leading-0">
           길을 잃거나 고립된 상황에서의 대응
         </span>
-      </div>
+      </button>
     </div>
   );
 }

--- a/src/components/features/widgets/SafeManualTab/index.tsx
+++ b/src/components/features/widgets/SafeManualTab/index.tsx
@@ -6,28 +6,44 @@ import {
 } from "@/constants/safeManual";
 import Tabs from "@entities/Tabs";
 import Spacing from "@shared/layout/Spacing";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useCallback } from "react";
 
 export default function SafeManualTab() {
+  const router = useRouter();
+
+  const searchParams = useSearchParams();
+
+  const onChangeHandler = useCallback(
+    (selectedTab: string | null) => {
+      if (selectedTab) {
+        const url = `/safe-manual/detail?manual=${selectedTab}`;
+        router.replace(url);
+      }
+    },
+    [router]
+  );
+
   return (
     <div className="flex flex-col h-full">
-      <Tabs>
+      <Tabs onChange={onChangeHandler}>
         <div className="px-6 border-b border-gray-30">
           <Tabs.TabList>
             {SAFE_MANUAL_TITLES.map((title, index) => (
               <Tabs.Tab
                 key={index}
                 label={title}
-                defaultSelected={index === 0}
+                defaultSelected={
+                  title === decodeURIComponent(searchParams.get("manual") || "")
+                }
               />
             ))}
           </Tabs.TabList>
         </div>
         <Tabs.Content<keyof typeof SAFE_MANUAL_CONTENTS>>
           {({ selectedTab }) => {
-            const selectedContent =
-              SAFE_MANUAL_CONTENTS[
-                selectedTab ? selectedTab : SAFE_MANUAL_TITLES[0]
-              ];
+            if (!selectedTab) return null;
+            const selectedContent = SAFE_MANUAL_CONTENTS[selectedTab];
             return (
               <div className="px-6 grow h-full overflow-y-scroll hide-scrollbar">
                 <Spacing size={12} />

--- a/src/hooks/bridge/useRouteBridge/index.ts
+++ b/src/hooks/bridge/useRouteBridge/index.ts
@@ -1,0 +1,42 @@
+import { useBridge } from "@/hooks/common/useBridge";
+import { useCallback } from "react";
+
+type RouteBridgePath =
+  | "course-detail"
+  | "start-travel"
+  | "mountain-course"
+  | "my-info"
+  | "hiking-log"
+  | "course-bookmark"
+  | "faq"
+  | "inquiry"
+  | "check-terms"
+  | "notification-setting"
+  | "change-password"
+  | "manual-detail";
+
+interface RouteBridgeRequest {
+  path: RouteBridgePath;
+  routeType: "push" | "replace";
+  params?: Record<string, string>[];
+}
+
+const useRouteBridge = ({ path, routeType, params }: RouteBridgeRequest) => {
+  const { request } = useBridge();
+
+  return useCallback(() => {
+    request({
+      requestMessage: {
+        method: "POST",
+        name: "route-to",
+        body: {
+          path,
+          routeType,
+          params,
+        },
+      },
+    });
+  }, [path, request, routeType, params]);
+};
+
+export default useRouteBridge;


### PR DESCRIPTION
### 개요

close #30 

### 작업사항

안전 메뉴얼 페이지에 브리지 로직을 추가하였습니다. 
기존에 라우팅하는 모든 페이지마다 다른 이름의 브리지를 만들어서 사용했었는데, 이는 아래와 같은 이유 때문이었습니다. 
1) 라우팅 방식이 주소마다 달랐다. 
  - 라우팅 방식이 Navigate, replace, push 등등이 존재하고, 이에 따라서 페이지마다 해야하는 라우팅 방식이 정해진 경우가 존재하였습니다. 
2) 페이지마다 받을 수 있는 브리지가 정해있다.
  - 모든 웹뷰 컴포넌트마다 받을 수 있는 브리지가 있다보니, 사용할 수 있는 페이지를 정해두었었습니다. 
3) 웹에서 앱의 path를 알아야 하는 문제가 존재한다.
  - 결국 라우팅의 경우 앱에서 실행하므로, 앱이 웹에 대한 path를, 혹은 웹이 앱에 대한 path를 알아야 하는 문제가 발생하였습니다. 

하지만 이번에는 동적 라우팅까지 매핑을 하게 되면 너무나도 많은 브리지가 나오게 되는 문제가 발생하였습니다. 
이에 따라서 라우팅을 하나의 브리지로 통일하게 되었습니다. 
추가적으로, 웹과 앱 둘중 하나는 상대의 데이터를 알아야 하는 문제가 존재하는데, 이는 서버의 역할인 앱이 하는 것이 맞다고 판단하여 해당 로직은 앱이 가져가도록 하였습니다. 

이번에 해당 내용 관련한 로직을 추가하였고, 추후에 따로 이슈 파서 전체적으로 마이그레이션 하도록 하겠습니다. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * SafeManualTab에서 탭 선택 시 URL 쿼리 파라미터와 동기화되는 기능이 추가되었습니다.
  * 매뉴얼 카테고리(ManualGridSection)가 클릭 가능한 버튼으로 변경되어, 각 카테고리 클릭 시 해당 상세 페이지로 이동할 수 있습니다.
  * 새로운 라우팅 훅(useRouteBridge)이 도입되어 다양한 페이지 이동 방식이 지원됩니다.

* **개선 사항**
  * Tabs 컴포넌트에 선택된 탭 변경 시 실행되는 onChange 콜백이 추가되었습니다.
  * 코스 상세 페이지 이동 시 라우팅 방식이 개선되었습니다.
  * 여러 페이지 컴포넌트에 React Suspense가 도입되어 비동기 로딩 처리 및 사용자 경험이 향상되었습니다.
  * 비밀번호 입력 필드의 취소 아이콘이 SVG에서 React 컴포넌트로 변경되어 일관된 UI가 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->