### PR TITLE
feat: 산행 페이지 구현

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,6 +3,7 @@
 @theme {
   --color-main-green: #2b7552;
   --color-green-10: #d7e5de;
+  --color-green-20: #eaf1ee;
 
   --color-kakao-yellow: #fae64d;
 

--- a/src/app/travel/page.tsx
+++ b/src/app/travel/page.tsx
@@ -1,0 +1,28 @@
+import CourseDetailMapSection from "@pages/map/CourseDetailMapSection";
+import TravelMapTagHeaderSection from "@pages/travel/TravelMapTabHeaderSection";
+import TravelMonitorSection from "@pages/travel/TravelMonitorSection";
+import PositionBottom from "@shared/layout/PositionBottom";
+import Spacing from "@shared/layout/Spacing";
+import BackButton from "@widgets/BackButton";
+import { Suspense } from "react";
+
+export default function TravelPage() {
+  return (
+    <div className="px-6">
+      <div className="z-10 fixed">
+        <Spacing size={4} />
+        <div className="z-10">
+          <BackButton />
+        </div>
+        <Spacing size={3} />
+        <Suspense>
+          <TravelMapTagHeaderSection />
+        </Suspense>
+      </div>
+      <CourseDetailMapSection />
+      <PositionBottom padding={4}>
+        <TravelMonitorSection />
+      </PositionBottom>
+    </div>
+  );
+}

--- a/src/components/common/shared/layout/PositionBottom/index.tsx
+++ b/src/components/common/shared/layout/PositionBottom/index.tsx
@@ -6,16 +6,18 @@ const DEFAULT_BOTTOM_SPACE = 18; // 하단 여백
 interface PositionBottomProps extends PropsWithChildren {
   bottom?: number;
   zIndex?: number;
+  padding?: number;
 }
 
 export default function PositionBottom({
   children,
   bottom = DEFAULT_BOTTOM_SPACE,
+  padding = 0,
 }: PositionBottomProps) {
   return (
     <div
       className={cn("absolute left-0 w-full")}
-      style={{ bottom, zIndex: 10 }}
+      style={{ bottom, zIndex: 10, padding: `${padding * 0.25}rem` }}
     >
       {children}
     </div>

--- a/src/components/features/pages/travel/TravelMapTabHeaderSection/index.tsx
+++ b/src/components/features/pages/travel/TravelMapTabHeaderSection/index.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import MapHeaderTag from "@shared/ui/MapHeaderTag";
+import MapHeaderTag from "@/components/common/shared/ui/MapHeaderTag";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useMemo } from "react";
 
-export default function MapTadHeaderSection() {
+export default function TravelMapTagHeaderSection() {
   const searchParams = useSearchParams();
   const router = useRouter();
   const selectedTagId = searchParams.get("tag") || "base";
@@ -30,8 +30,7 @@ export default function MapTadHeaderSection() {
           text={text}
           isSelected={id === selectedTagId}
           onClickHandler={() => {
-            //TODO: 상수 데이터 따로 빼기
-            router.replace(`/map?tag=${id}`);
+            router.replace(`/travel?tag=${id}`);
           }}
         />
       ))}

--- a/src/components/features/pages/travel/TravelMonitorSection/index.tsx
+++ b/src/components/features/pages/travel/TravelMonitorSection/index.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import Spacing from "@shared/layout/Spacing";
+
+export default function TravelMonitorSection() {
+  return (
+    <section className="bg-white rounded-xl z-50 px-4">
+      <div className="flex justify-center items-center gap-6 -translate-y-1/2">
+        <button className="bg-main-green rounded-full w-16 h-16 flex justify-center items-center gap-2  active:scale-95 transition-transform duration-200 ease-in-out">
+          <div className="h-8 w-1.5 bg-white rounded-xs" />
+          <div className="h-8 w-1.5 bg-white rounded-xs" />
+        </button>
+        <button className="bg-main-green rounded-full w-16 h-16 flex justify-center items-center active:scale-95 transition-transform duration-200 ease-in-out">
+          <div className="bg-white w-5 h-5 rounded-xs" />
+        </button>
+      </div>
+      <p className="text-3xl font-semibold text-center">00:00:00</p>
+      <span className="text-center text-gray-20">산행 시간</span>
+
+      <Spacing size={4} />
+
+      <div className="bg-green-20 rounded-xl p-4 flex justify-between items-center ">
+        <div className="flex gap-2">
+          <span>🏃‍♂️‍➡️</span>
+          <div>
+            <p className="font-semibold text-base">1.89</p>
+            <p className="text-sm text-end">km</p>
+          </div>
+        </div>
+        <div className="h-10 border border-gray-20 opacity-50" />
+        <div className="flex gap-2">
+          <span>🔥</span>
+          <p className="font-semibold text-base">03:24</p>
+        </div>
+        <div className="h-10 border border-gray-20 opacity-50" />
+        <div className="flex gap-2">
+          <p>⛰️</p>
+          <p className="font-semibold text-base">01:20</p>
+        </div>
+      </div>
+
+      <Spacing size={4} />
+    </section>
+  );
+}


### PR DESCRIPTION
### 개요

close #33 

### 작업사항

산행 페이지를 구현하였습니다. 

<div align="center">
<img width="50%" src="https://github.com/user-attachments/assets/63138ede-1601-44b5-92b9-f4c205a62091"/>
</div>

해당 pr에는 큰 변경점이나 주의할 점은 존재하지 않습니다!
기존에 잘 구현되어있는 컴포넌트를 잘 조합하였고, 필요에 따라 부가적인 컴포넌트를 구현하게 되었습니다. 

color-green-20 색상이 추가되었습니다. 
PoritionBottom 컴포넌트에 padding props가 추가되었습니다. 

해당 페이지 전부를 웹뷰로 구현하게 되어, 추후에 부수적인 음성 및 진동, 알림등의 기능을 브리지를 통해서 진행할 예정입니다. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 트래블 페이지가 추가되어, 고정 헤더와 지도 태그 선택, 상세 지도 영역, 하단 모니터링 섹션이 제공됩니다.
  * 지도 태그를 선택할 수 있는 TravelMapTagHeaderSection 컴포넌트가 도입되었습니다.
  * 산행 시간, 거리, 칼로리, 고도 정보를 시각적으로 보여주는 TravelMonitorSection 컴포넌트가 추가되었습니다.

* **스타일**
  * 새로운 녹색 계열 CSS 변수(`--color-green-20`)가 글로벌 스타일에 추가되었습니다.
  * PositionBottom 컴포넌트에 패딩 옵션이 추가되어 레이아웃 조정이 유연해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->