### PR TITLE
feat: 코스 직접 검색 화면 구현

### DIFF
--- a/src/app/course/[mountainName]/page.tsx
+++ b/src/app/course/[mountainName]/page.tsx
@@ -1,8 +1,8 @@
 import CourseSearchBarSection from "@pages/course/CourseSearchNarSection";
 import CourseTabSection from "@pages/course/CourseTabBarSection";
+import Flex from "@shared/layout/Flex";
 import Spacing from "@shared/layout/Spacing";
-import BackButton from "@/components/features/widgets/BackButton";
-import Flex from "@/components/common/shared/layout/Flex";
+import BackButton from "@widgets/BackButton";
 import { Suspense } from "react";
 
 export default function MountainCoursePage() {

--- a/src/app/course/search/page.tsx
+++ b/src/app/course/search/page.tsx
@@ -1,0 +1,39 @@
+import CourseDetailMapSection from "@pages/map/CourseDetailMapSection";
+import Spacing from "@shared/layout/Spacing";
+import Button from "@shared/ui/Button";
+import BackButton from "@widgets/BackButton";
+
+export default function CourseSearchPage() {
+  return (
+    <div className="relative w-screen h-screen">
+      <div className="px-6 z-10 fixed w-full">
+        <Spacing size={4} />
+        <BackButton />
+        <Spacing size={3} />
+
+        <input
+          type="text"
+          placeholder="출발지 입력"
+          className="w-full px-4 py-2 bg-white rounded-xl shadow-sm"
+        />
+        <Spacing size={4} />
+        <input
+          type="text"
+          placeholder="경유지 입력"
+          className="w-full px-4 py-2 bg-white rounded-xl shadow-sm"
+        />
+        <Spacing size={4} />
+        <input
+          type="text"
+          placeholder="도착지 입력"
+          className="w-full px-4 py-2 bg-white rounded-xl shadow-sm"
+        />
+
+        <Spacing size={4} />
+        <Button fullWidth>검색하기</Button>
+      </div>
+
+      <CourseDetailMapSection />
+    </div>
+  );
+}

--- a/src/components/features/pages/course/CourseSearchNarSection/index.tsx
+++ b/src/components/features/pages/course/CourseSearchNarSection/index.tsx
@@ -1,9 +1,27 @@
+"use client";
+
+import useRouteBridge from "@/hooks/bridge/useRouteBridge";
 import SearchInput from "@shared/ui/SearchInput";
+import { FocusEvent, useCallback } from "react";
 
 export default function CourseSearchBarSection() {
+  const routeToCourseSearch = useRouteBridge({
+    path: "course-search",
+    routeType: "push",
+  });
+
+  const onFocus = useCallback(
+    (e: FocusEvent<HTMLInputElement>) => {
+      e.preventDefault();
+      e.currentTarget.blur();
+      routeToCourseSearch();
+    },
+    [routeToCourseSearch]
+  );
+
   return (
     <section>
-      <SearchInput placeholder="코스 지점 직접 검색" />
+      <SearchInput placeholder="코스 지점 직접 검색" onFocus={onFocus} />
     </section>
   );
 }

--- a/src/hooks/bridge/useRouteBridge/index.ts
+++ b/src/hooks/bridge/useRouteBridge/index.ts
@@ -2,18 +2,19 @@ import { useBridge } from "@/hooks/common/useBridge";
 import { useCallback } from "react";
 
 type RouteBridgePath =
+  | "change-password"
+  | "check-terms"
+  | "course-bookmark"
   | "course-detail"
-  | "start-travel"
+  | "course-search"
+  | "faq"
+  | "hiking-log"
+  | "inquiry"
+  | "manual-detail"
   | "mountain-course"
   | "my-info"
-  | "hiking-log"
-  | "course-bookmark"
-  | "faq"
-  | "inquiry"
-  | "check-terms"
   | "notification-setting"
-  | "change-password"
-  | "manual-detail";
+  | "start-travel";
 
 interface RouteBridgeRequest {
   path: RouteBridgePath;


### PR DESCRIPTION
### 개요

close #20

### 작업사항

코스를 직접 검색할 수 있는 페이지를 구현하였습니다. 

<div align="center">
<img width="50%" src="https://github.com/user-attachments/assets/0af63de2-f360-482c-bde1-c0362ea274ce"/>
</div>

기존에 산을 검색한 이후 해당 산의 코스들이 리스트업 되어 보이는 화면에서, 직접 지점을 선택해서 코스를 설정할 수 있는 페이지입니다. 
이전에 만들어 두었던 <MapWithCurrentPositionMark/> 컴포넌트에 input과 Button을 띄워서 구현하였습니다. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 코스 검색 페이지가 추가되어 출발지, 경유지, 도착지 입력 및 지도와 연동된 검색 기능을 제공합니다.

* **버그 수정**
  * 코스 검색 입력란에 포커스 시 자동으로 검색 페이지로 이동하도록 개선되었습니다.

* **기타**
  * 내부 라우팅 경로가 정비되어 "course-search" 등 새로운 경로가 추가되었습니다.  
  * 일부 컴포넌트의 import 경로가 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->