### PR TITLE
fix: 코스 상세 페이지에서 맵 태그 선택시 자동으로 바텀시트가 열리던 버그 수정

### DIFF
--- a/src/components/common/entities/BottomSheet/index.tsx
+++ b/src/components/common/entities/BottomSheet/index.tsx
@@ -160,7 +160,7 @@ export default function BottomSheet({ debug, children }: BottomSheetProps) {
     <div
       ref={bottomSheet}
       className={cn(
-        "rounded-2xl bg-white overflow-hidden transition-all transform-gpu shadow-md"
+        "rounded-3xl bg-white overflow-hidden transition-all transform-gpu shadow-md"
       )}
     >
       <button

--- a/src/components/common/entities/BottomSheet/index.tsx
+++ b/src/components/common/entities/BottomSheet/index.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import { cn } from "@/utils/cn";
-import { PropsWithChildren, useEffect, useRef, useState } from "react";
+import { memo, PropsWithChildren, useEffect, useRef, useState } from "react";
 
 const MIN_CONTENT_HEIGHT = 0; // 최소 컨텐츠 높이
 const SNAP_THRESHOLD = 1; // 스냅 임계값
@@ -11,13 +11,17 @@ interface BottomSheetProps extends PropsWithChildren {
   debug?: boolean;
 }
 
-export default function BottomSheet({ debug, children }: BottomSheetProps) {
+export default memo(function BottomSheet({
+  debug,
+  children,
+}: BottomSheetProps) {
   const [isReady, setIsReady] = useState(false);
   const [isPressed, setIsPressed] = useState(false);
   const [startY, setStartY] = useState(0); // 드래그 시작 Y 좌표
   const [currentY, setCurrentY] = useState(0); // 현재 드래그 Y 좌표
   const [contentHeight, setContentHeight] = useState(0); // 현재 컨텐츠 높이
   const [maxContentHeight, setMaxContentHeight] = useState(0); // 최대 컨텐츠 높이
+  const [isOpen, setIsOpen] = useState(true); // BottomSheet 열림 상태
 
   const bottomSheet = useRef<HTMLDivElement | null>(null);
   const bottomSheetContent = useRef<HTMLDivElement | null>(null);
@@ -29,9 +33,9 @@ export default function BottomSheet({ debug, children }: BottomSheetProps) {
       setContentHeight(bottomSheetContent.current.scrollHeight);
       setIsReady(true);
     }
-  }, [children]);
+  }, []);
 
-  // 마우스 이벤트 핸들러
+  // 마우스의 움직임에 따라 BottomSheet의 높이를 조정하는 핸들러
   const handleMove = (e: MouseEvent) => {
     if (!isPressed) return;
 
@@ -48,6 +52,7 @@ export default function BottomSheet({ debug, children }: BottomSheetProps) {
     }
   };
 
+  // 마우스가 어디로 이동했는지에 따라 열거나 닫는 핸들러
   const handleMouseUp = (e: MouseEvent) => {
     if (!isPressed) return;
 
@@ -64,8 +69,10 @@ export default function BottomSheet({ debug, children }: BottomSheetProps) {
 
     if (Math.abs(deltaY) > SNAP_THRESHOLD) {
       if (deltaY > 0) {
+        setIsOpen(false);
         finalHeight = MIN_CONTENT_HEIGHT;
       } else {
+        setIsOpen(true);
         finalHeight = maxContentHeight;
       }
     }
@@ -73,7 +80,7 @@ export default function BottomSheet({ debug, children }: BottomSheetProps) {
     setContentHeight(finalHeight);
   };
 
-  // 터치 이벤트 핸들러
+  // 손가락 터치에 따라 BottomSheet의 높이를 조정하는 핸들러
   const handleTouchMove = (e: TouchEvent) => {
     if (!isPressed) return;
     e.preventDefault();
@@ -92,6 +99,7 @@ export default function BottomSheet({ debug, children }: BottomSheetProps) {
     }
   };
 
+  // 손가락 터치가 끝났을 때 BottomSheet를 열거나 닫는 핸들러
   const handleTouchEnd = (e: TouchEvent) => {
     if (!isPressed) return;
 
@@ -108,8 +116,10 @@ export default function BottomSheet({ debug, children }: BottomSheetProps) {
 
     if (Math.abs(deltaY) > SNAP_THRESHOLD) {
       if (deltaY > 0) {
+        setIsOpen(false);
         finalHeight = MIN_CONTENT_HEIGHT;
       } else {
+        setIsOpen(true);
         finalHeight = maxContentHeight;
       }
     }
@@ -191,6 +201,7 @@ export default function BottomSheet({ debug, children }: BottomSheetProps) {
           <p>최소 높이: {MIN_CONTENT_HEIGHT}px</p>
           <p>드래그 중: {isPressed ? "Yes" : "No"}</p>
           <p>준비 완료: {isReady ? "Yes" : "No"}</p>
+          <p>열림 상태: {isOpen ? "Yes" : "No"}</p>
         </div>
       )}
 
@@ -206,4 +217,4 @@ export default function BottomSheet({ debug, children }: BottomSheetProps) {
       </div>
     </div>
   );
-}
+});

--- a/src/components/common/entities/Carousel/index.tsx
+++ b/src/components/common/entities/Carousel/index.tsx
@@ -1,12 +1,14 @@
 "use client";
 
 import { cn } from "@/utils/cn";
+import Spacing from "@shared/layout/Spacing";
 import { ReactNode, useEffect, useRef, useState } from "react";
 
 interface CarouselProps {
   items: ReactNode[];
 }
 
+//TODO: 캐러샐 ui를 사용하는 곳에서 변경 가능하게 수정 필요
 export default function Carousel({ items }: CarouselProps) {
   const [prevX, setPrevX] = useState(0);
   const [x, setX] = useState(0);
@@ -85,7 +87,8 @@ export default function Carousel({ items }: CarouselProps) {
           </div>
         ))}
       </div>
-      <div className="flex items-center justify-center gap-2 mt-4">
+      <Spacing size={1} />
+      <div className="flex items-center justify-center gap-2">
         {items.map((_, index) => (
           <div
             className={cn("w-2 h-2 rounded-full", {

--- a/src/components/common/entities/CourseBaseTab/index.tsx
+++ b/src/components/common/entities/CourseBaseTab/index.tsx
@@ -24,13 +24,16 @@ export default function CourseBaseTab({
 
   return (
     <>
-      <div className="flex items-center justify-center bg-gray-30 rounded-full mx-auto w-fit">
+      <div className="flex items-center justify-center bg-gray-30 rounded-full mx-auto w-full">
         {courseList.map((courseName, index) => (
           <button
-            className={cn("px-4 py-1 rounded-full transition-all", {
-              "border border-main-green bg-white":
-                selectedCourseName === courseName,
-            })}
+            className={cn(
+              "px-4 py-1 rounded-full transition-all grow shrink-0",
+              {
+                "border border-main-green bg-white":
+                  selectedCourseName === courseName,
+              }
+            )}
             key={`${index}-${courseName}`}
             onClick={() => {
               if (selectedCourseName === courseName) return;

--- a/src/components/common/shared/ui/icons/XIcon/index.tsx
+++ b/src/components/common/shared/ui/icons/XIcon/index.tsx
@@ -3,24 +3,11 @@ import Image from "next/image";
 import { ComponentProps } from "react";
 
 const DEFAULT_ALT = "닫기";
-const DEFAULT_WIDTH = 24;
-const DEFAULT_HEIGHT = 24;
 
-interface XIconProps
-  extends Omit<
-    ComponentProps<typeof Image>,
-    "src" | "width" | "height" | "alt"
-  > {
+interface XIconProps extends Omit<ComponentProps<typeof Image>, "src" | "alt"> {
   alt?: string;
-  width?: number;
-  height?: number;
 }
 
-export default function XIcon({
-  alt = DEFAULT_ALT,
-  width = DEFAULT_WIDTH,
-  height = DEFAULT_HEIGHT,
-  ...props
-}: XIconProps) {
-  return <Image src={X} alt={alt} width={width} height={height} {...props} />;
+export default function XIcon({ alt = DEFAULT_ALT, ...props }: XIconProps) {
+  return <Image src={X} alt={alt} {...props} />;
 }

--- a/src/components/features/pages/map/CourseDetailBottomSheetSection/index.tsx
+++ b/src/components/features/pages/map/CourseDetailBottomSheetSection/index.tsx
@@ -15,9 +15,9 @@ export default function CourseDetailBottomSheetSection() {
     <section>
       <BottomSheet>
         <CourseBaseTab courseList={courseList} />
-        <Spacing size={4} />
+        <Spacing size={2} />
         <CourseMetaDataUi difficulty="easy" distance={123} time={23} />
-        <Spacing size={4} />
+        <Spacing size={2} />
 
         <Carousel
           items={[
@@ -25,6 +25,7 @@ export default function CourseDetailBottomSheetSection() {
             <CourseImageInfoSection key={2} />,
           ]}
         />
+        <Spacing size={1} />
       </BottomSheet>
     </section>
   );

--- a/src/components/features/pages/map/CourseWeatherClothesInfoSection/index.tsx
+++ b/src/components/features/pages/map/CourseWeatherClothesInfoSection/index.tsx
@@ -3,7 +3,7 @@ import SunnyIcon from "@icons/SunnyIcon";
 
 export default function CourseWeatherClothesInfoSection() {
   return (
-    <div className="grid grid-cols-2 bg-green-10 rounded-2xl p-2">
+    <div className="grid grid-cols-2 bg-green-10 rounded-2xl p-2.5">
       <p className="font-bold text-gray-20">기상 정보</p>
       <p className="font-bold text-gray-20">산행 복장</p>
       <div className="flex items-center justify-around">


### PR DESCRIPTION
### 개요

close #24 

### 작업사항

기존에 코스 상세 페이지에서 맵 태그를 선택했을 때 의도하지 않게 자동으로 바텀시트가 열렸습니다. 

<div align="center">
<img width="50%" src="https://github.com/user-attachments/assets/eea97473-6700-40d0-8abf-48d9e8626c95"/>
</div>

맵 태그를 선택하면 쿼리 스트링이 변경되어 해당 페이지가 재랜더링 되고, 이로 인해서 바텀시트도 재랜더링 되면서 열리게 됩니다. 
쿼리 스트링이 변경되어 상위 컴포넌트가 렌더링이 되어도, 바텀시트는 렌더링 되지 않게 하기 위해 memo를 사용하여 수정하게 되었습니다. 

<div align="center">
<img width="50%" src="https://github.com/user-attachments/assets/4de6409b-c892-483c-96fa-3d3b9d08afe8"/>
</div>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * BottomSheet 컴포넌트의 열림/닫힘 상태가 드래그 방향에 따라 변경됩니다.  
  * BottomSheet 디버그 패널에 현재 열림 상태가 표시됩니다.

* **스타일**
  * BottomSheet의 모서리 둥글기와 CourseDetailBottomSheetSection 내 컴포넌트 간 간격이 조정되었습니다.
  * CourseBaseTab의 탭 버튼이 전체 너비로 고르게 확장되도록 레이아웃이 개선되었습니다.
  * Carousel 컴포넌트의 페이지네이션 점 위에 간격이 추가되었습니다.
  * CourseWeatherClothesInfoSection의 패딩이 약간 늘어났습니다.
  * XIcon 아이콘의 크기 지정 방식이 변경되어, 이제 호출자가 자유롭게 크기를 지정할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->