### PR TITLE
feat: Stack Link 라이브러리 구현

### DIFF
--- a/src/api/_instances/authenticatedApi/index.ts
+++ b/src/api/_instances/authenticatedApi/index.ts
@@ -1,4 +1,4 @@
-import { isInIframe } from "@/service/StackLink";
+import { isInStackFrame } from "@/service/StackLink";
 import axios, { AxiosResponse } from "axios";
 
 const authenticatedApi = axios.create({
@@ -19,7 +19,7 @@ const authenticatedApi = axios.create({
 
 authenticatedApi.interceptors.request.use(
   async (config) => {
-    if (isInIframe()) {
+    if (isInStackFrame()) {
       await new Promise((resolve) => setTimeout(resolve, 99999));
     }
 

--- a/src/api/_instances/authenticatedApi/index.ts
+++ b/src/api/_instances/authenticatedApi/index.ts
@@ -1,16 +1,28 @@
+import { isInIframe } from "@/service/StackLink";
 import axios, { AxiosResponse } from "axios";
 
 const authenticatedApi = axios.create({
-  baseURL: `${process.env.NEXT_PUBLIC_BASE_URL}`?.replace(/\/$/, ""),
+  baseURL: process.env.NEXT_PUBLIC_BASE_URL?.replace(/\/$/, ""),
   timeout: 5000,
-  headers: {
-    "Content-Type": "application/json",
-    Accept: "*/*",
-  },
+  headers:
+    process.env.NODE_ENV === "development"
+      ? {
+          "ngrok-skip-browser-warning": "true",
+          "Content-Type": "application/json",
+          Accept: "*/*",
+        }
+      : {
+          "Content-Type": "application/json",
+          Accept: "*/*",
+        },
 });
 
 authenticatedApi.interceptors.request.use(
   async (config) => {
+    if (isInIframe()) {
+      await new Promise((resolve) => setTimeout(resolve, 99999));
+    }
+
     const token = localStorage.getItem("accessToken");
 
     if (token) {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,9 @@
+import ModalProvider from "@/service/modal/provider";
+import { StackLinkProvider } from "@/service/StackLink";
 import TanstackQueryProvider from "@entities/TanstackQueryProvider";
 import type { Metadata } from "next";
 import localFont from "next/font/local";
 import "./globals.css";
-import ModalProvider from "@/service/modal/provider";
 
 export const metadata: Metadata = {
   title: "산악구조",
@@ -68,7 +69,9 @@ export default function RootLayout({
     <html lang="ko" className={font.className}>
       <body className="select-none">
         <ModalProvider>
-          <TanstackQueryProvider>{children}</TanstackQueryProvider>
+          <TanstackQueryProvider>
+            <StackLinkProvider>{children}</StackLinkProvider>
+          </TanstackQueryProvider>
         </ModalProvider>
       </body>
     </html>

--- a/src/components/features/pages/course/CourseTabBarSection/index.tsx
+++ b/src/components/features/pages/course/CourseTabBarSection/index.tsx
@@ -9,6 +9,7 @@ import { Suspense } from "@suspensive/react";
 import CourseListWithBookmarkMutate from "@widgets/CourseListWithBookmarkMutate";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 
+import { StackLink } from "@/service/StackLink";
 import CourseTabBarSectionSkeleton from "./CourseTabBarSection.skeleton";
 
 const tabTitleList = [
@@ -37,6 +38,10 @@ export default Suspense.with(
     const { data: courseList } = useCoursesOfMountainQuery(mountainId);
 
     const { courses } = courseList;
+
+    if (!courses) {
+      return <div className="text-center text-gray-500">코스가 없습니다.</div>;
+    }
 
     return (
       <section className="flex flex-col flex-1 overflow-hidden">
@@ -67,13 +72,15 @@ export default Suspense.with(
         <Spacing size={4} />
         <ul className="flex flex-col gap-4 bg-gray-200 p-6 overflow-y-auto flex-1">
           {courses.map(({ id, ...props }, index) => (
-            <div
-              key={`${id}-${index}`}
-              onClick={routeCourseDetail}
-              typeof="button"
-            >
-              <CourseListWithBookmarkMutate id={id} {...props} />
-            </div>
+            <StackLink href={`/map/course-detail/`} key={id}>
+              <div
+                key={`${id}-${index}`}
+                onClick={routeCourseDetail}
+                role="button"
+              >
+                <CourseListWithBookmarkMutate id={id} {...props} />
+              </div>
+            </StackLink>
           ))}
         </ul>
       </section>

--- a/src/components/features/pages/course/MountainGridSection/index.tsx
+++ b/src/components/features/pages/course/MountainGridSection/index.tsx
@@ -19,14 +19,16 @@ export default function MountainGridSection() {
   return (
     <section className="flex grow gap-4">
       <div className="flex flex-col w-full h-fit gap-4">
-        <StackLink href="/course/무등산" preLoad>
-          <button
+        {/* TODO: href 하드코딩 피하기 */}
+        <StackLink href="/course/1?sort=my" preLoad>
+          <div
             className="h-72 rounded-2xl flex items-center justify-center relative overflow-hidden"
             style={{
               backgroundImage: `url('/images/mudeungsan.jpg')`, //TODO: 하드 코딩 없애기 -> 정적 이미지 주소를 관리하는 방법 고안 필요
               backgroundPosition: "center",
               backgroundRepeat: "no-repeat",
             }}
+            role="button"
             onClick={routeToCoursePage}
           >
             <div className="absolute top-0 right-0 bg-black opacity-40 w-full h-full" />
@@ -48,17 +50,15 @@ export default function MountainGridSection() {
             >
               무등산
             </Text>
-          </button>
+          </div>
         </StackLink>
         {/* TODO: 실제 산으로 변경하기 */}
         <div className="h-72 bg-amber-100 rounded-2xl" />
-        {/* <div className="h-72 bg-amber-100 rounded-2xl" /> */}
       </div>
       <div className="flex flex-col w-full h-fit gap-4">
         <Spacing size={12} />
         <div className="h-72 bg-amber-100 rounded-2xl" />
-        {/* <div className="h-72 bg-amber-100 rounded-2xl" />
-        <div className="h-72 bg-amber-100 rounded-2xl" /> */}
+        <div className="h-72 bg-amber-100 rounded-2xl" />
       </div>
     </section>
   );

--- a/src/components/features/pages/course/MountainGridSection/index.tsx
+++ b/src/components/features/pages/course/MountainGridSection/index.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import useRouteBridge from "@/hooks/feature/bridge/useRouteBridge";
+import { StackLink } from "@/service/StackLink";
 import Spacing from "@shared/layout/Spacing";
 import Text from "@shared/ui/Text";
 
@@ -18,45 +19,46 @@ export default function MountainGridSection() {
   return (
     <section className="flex grow gap-4">
       <div className="flex flex-col w-full h-fit gap-4">
-        <button
-          className="h-72 rounded-2xl flex items-center justify-center relative overflow-hidden"
-          style={{
-            backgroundImage: `url('/images/mudeungsan.jpg')`, //TODO: 하드 코딩 없애기 -> 정적 이미지 주소를 관리하는 방법 고안 필요
-            backgroundPosition: "center",
-            backgroundRepeat: "no-repeat",
-          }}
-          onClick={routeToCoursePage}
-        >
-          <div className="absolute top-0 right-0 bg-black opacity-40 w-full h-full" />
-          <div className="absolute top-6 right-4">
+        <StackLink href="/course/무등산" preLoad>
+          <button
+            className="h-72 rounded-2xl flex items-center justify-center relative overflow-hidden"
+            style={{
+              backgroundImage: `url('/images/mudeungsan.jpg')`, //TODO: 하드 코딩 없애기 -> 정적 이미지 주소를 관리하는 방법 고안 필요
+              backgroundPosition: "center",
+              backgroundRepeat: "no-repeat",
+            }}
+            onClick={routeToCoursePage}
+          >
+            <div className="absolute top-0 right-0 bg-black opacity-40 w-full h-full" />
+            <div className="absolute top-6 right-4">
+              <Text
+                fontSize="text-4xl"
+                fontWeight="font-bold"
+                color="text-white"
+                zIndex="z-10"
+              >
+                광주
+              </Text>
+            </div>
             <Text
               fontSize="text-4xl"
               fontWeight="font-bold"
               color="text-white"
               zIndex="z-10"
             >
-              광주
+              무등산
             </Text>
-          </div>
-          <Text
-            fontSize="text-4xl"
-            fontWeight="font-bold"
-            color="text-white"
-            zIndex="z-10"
-          >
-            무등산
-          </Text>
-        </button>
-
+          </button>
+        </StackLink>
         {/* TODO: 실제 산으로 변경하기 */}
         <div className="h-72 bg-amber-100 rounded-2xl" />
-        <div className="h-72 bg-amber-100 rounded-2xl" />
+        {/* <div className="h-72 bg-amber-100 rounded-2xl" /> */}
       </div>
       <div className="flex flex-col w-full h-fit gap-4">
         <Spacing size={12} />
         <div className="h-72 bg-amber-100 rounded-2xl" />
-        <div className="h-72 bg-amber-100 rounded-2xl" />
-        <div className="h-72 bg-amber-100 rounded-2xl" />
+        {/* <div className="h-72 bg-amber-100 rounded-2xl" />
+        <div className="h-72 bg-amber-100 rounded-2xl" /> */}
       </div>
     </section>
   );

--- a/src/service/StackLink/components/GoBackTrigger/index.tsx
+++ b/src/service/StackLink/components/GoBackTrigger/index.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useEffect, useId, useState } from "react";
+import { createPortal } from "react-dom";
+
+import useStackContext from "../../hooks/useStackContext";
+// import Iframe from "../Iframe";
+
+import { useRouter } from "next/navigation";
+
+export default function GoBackTrigger() {
+  const [isTouching, setIsTouching] = useState(false);
+  const [startX, setStartX] = useState(0);
+  const [currentX, setCurrentX] = useState(0);
+  const [isNavigating, setIsNavigating] = useState(false);
+
+  const goBackTriggerElementId = useId();
+
+  const { portalElement, history, pop } = useStackContext();
+
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!isTouching) return;
+
+    const main = document.getElementById("stack-main");
+    if (!main) {
+      console.error(
+        "[GoBackTrigger] Main element not found. Ensure it exists in your layout."
+      );
+      return;
+    }
+
+    const handleTouchMove = (e: TouchEvent) => {
+      e.preventDefault();
+      const newX = e.touches[0].clientX;
+      setCurrentX(newX);
+
+      const deltaX = newX - startX;
+      if (deltaX > 0) {
+        main.style.transform = `translateX(${deltaX}px)`;
+      }
+    };
+
+    const handleTouchEnd = () => {
+      const deltaX = currentX - startX;
+
+      if (deltaX > 100) {
+        setIsNavigating(true);
+        main.style.transform = "translateX(100%)";
+        main.style.transition = "transform 0.2s ease-in-out";
+
+        pop();
+
+        setTimeout(() => {
+          router.back();
+        }, 200);
+
+        return;
+      }
+
+      // 원래 위치로 복귀
+      main.style.transform = "translateX(0px)";
+      setIsTouching(false);
+    };
+
+    window.addEventListener("touchmove", handleTouchMove, { passive: false });
+    window.addEventListener("touchend", handleTouchEnd);
+
+    return () => {
+      window.removeEventListener("touchmove", handleTouchMove);
+      window.removeEventListener("touchend", handleTouchEnd);
+    };
+  }, [isTouching, startX, currentX, history, router, pop]);
+
+  useEffect(() => {
+    const main = document.getElementById("stack-main");
+    if (!main) {
+      console.error(
+        "[StackLink] Main element not found. Ensure it exists in your layout."
+      );
+      return;
+    }
+  }, []);
+
+  return (
+    <>
+      {portalElement &&
+        !isNavigating &&
+        createPortal(
+          <>
+            {history.length > 0 && (
+              <div
+                id={goBackTriggerElementId}
+                className="fixed w-screen h-screen top-0 left-0 transform-gpu -z-50"
+              >
+                {/* <Iframe
+                  className="w-screen h-screen -z-50"
+                  src={history[history.length - 1][0]}
+                /> */}
+              </div>
+            )}
+          </>,
+          portalElement
+        )}
+
+      {history.length > 0 &&
+        createPortal(
+          <div
+            className="fixed w-3 h-screen top-0 transform-gpu select-none z-50"
+            role="button"
+            onTouchStart={(e) => {
+              const touchX = e.touches[0].clientX;
+              setStartX(touchX);
+              setCurrentX(touchX);
+              setIsTouching(true);
+            }}
+          />,
+          document.body
+        )}
+    </>
+  );
+}

--- a/src/service/StackLink/components/Iframe/index.tsx
+++ b/src/service/StackLink/components/Iframe/index.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { HTMLAttributes } from "react";
+
+interface IframeProps extends HTMLAttributes<HTMLIFrameElement> {
+  src: string;
+}
+
+export default function Iframe({ src, ...props }: IframeProps) {
+  return (
+    <iframe src={src} {...props} className="w-screen h-screen hide-scrollbar" />
+  );
+}

--- a/src/service/StackLink/components/StackLink/index.tsx
+++ b/src/service/StackLink/components/StackLink/index.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import {
+  PropsWithChildren,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { createPortal } from "react-dom";
+import useStackContext from "../../hooks/useStackContext";
+import GoBackTrigger from "../GoBackTrigger";
+import Iframe from "../Iframe";
+
+const DEFAULT_DURATION = 300;
+
+interface StackLinkedProps extends PropsWithChildren {
+  href: string;
+  duration?: number;
+  preLoad?: boolean;
+}
+
+export default function StackLink({
+  href,
+  children,
+  preLoad = false,
+  duration = DEFAULT_DURATION,
+}: StackLinkedProps) {
+  const [portalElement, setPortalElement] = useState<HTMLElement | null>(null);
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const timerRef = useRef<NodeJS.Timeout | null>(null);
+  const originalStylesRef = useRef<{
+    transition: string;
+    transform: string;
+    zIndex: string;
+  }>({
+    transition: "",
+    transform: "",
+    zIndex: "",
+  });
+
+  const router = useRouter();
+  const { push } = useStackContext();
+
+  useEffect(() => {
+    router.prefetch(href);
+
+    const element = document.getElementById("stack-root") || document.body;
+    setPortalElement(element);
+
+    const currentIframe = iframeRef.current;
+
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+
+      const main = document.getElementById("stack-main");
+      if (main && originalStylesRef.current) {
+        main.style.transition = originalStylesRef.current.transition;
+        main.style.transform = originalStylesRef.current.transform;
+        main.style.zIndex = originalStylesRef.current.zIndex;
+      }
+
+      if (currentIframe) {
+        currentIframe.remove();
+      }
+    };
+  }, [href, router]);
+
+  const slideScreen = useCallback(() => {
+    if (typeof window === "undefined") return;
+    const main = document.getElementById("stack-main");
+    if (!main) {
+      console.error(
+        "[StackLink] Main element not found. Ensure it exists in your layout."
+      );
+      return;
+    }
+
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+    }
+
+    originalStylesRef.current = {
+      transition: main.style.transition,
+      transform: main.style.transform,
+      zIndex: main.style.zIndex,
+    };
+
+    main.style.transition = `transform ${duration}ms ease-in-out`;
+    main.style.transform = "translateX(-20%)";
+
+    if (!iframeRef.current) {
+      console.error("Iframe reference is not set.");
+      return;
+    }
+
+    iframeRef.current.style.transform = "translateX(-100%)";
+    iframeRef.current.style.transition = `transform ${duration}ms ease-in-out`;
+
+    // 스택에 현재 경로와 이동한 경로 추가
+    push([window.location.href, href]);
+
+    timerRef.current = setTimeout(() => {
+      main.style.transition = "";
+      main.style.transform = "translateX(0)";
+      main.style.zIndex = "-999";
+      router.push(href);
+    }, duration);
+  }, [duration, href, push, router]);
+
+  return (
+    <>
+      <div onClick={slideScreen} className="transform-gpu">
+        {children}
+        {portalElement &&
+          createPortal(
+            <div
+              ref={iframeRef}
+              className="fixed w-screen h-screen top-0 transform-gpu translate-x-full bg-white z-[999] select-none"
+            >
+              {preLoad && <Iframe src={href} />}
+            </div>,
+            portalElement
+          )}
+      </div>
+      <GoBackTrigger />
+    </>
+  );
+}

--- a/src/service/StackLink/components/StackLink/index.tsx
+++ b/src/service/StackLink/components/StackLink/index.tsx
@@ -29,7 +29,7 @@ export default function StackLink({
 }: StackLinkedProps) {
   const [portalElement, setPortalElement] = useState<HTMLElement | null>(null);
   const iframeRef = useRef<HTMLIFrameElement>(null);
-  const timerRef = useRef<NodeJS.Timeout | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const originalStylesRef = useRef<{
     transition: string;
     transform: string;

--- a/src/service/StackLink/context/stackContext/index.ts
+++ b/src/service/StackLink/context/stackContext/index.ts
@@ -1,0 +1,7 @@
+import { createContext } from "react";
+
+import { StackContextType } from "../../types";
+
+const StackContext = createContext<StackContextType | undefined>(undefined);
+
+export default StackContext;

--- a/src/service/StackLink/hooks/useStackContext/index.ts
+++ b/src/service/StackLink/hooks/useStackContext/index.ts
@@ -1,0 +1,13 @@
+import { useContext } from "react";
+
+import StackContext from "../../context/stackContext";
+
+const useStackContext = () => {
+  const context = useContext(StackContext);
+  if (!context) {
+    throw new Error("useStackContext must be used within a StackProvider");
+  }
+  return context;
+};
+
+export default useStackContext;

--- a/src/service/StackLink/index.tsx
+++ b/src/service/StackLink/index.tsx
@@ -1,0 +1,3 @@
+export { default as StackLink } from "./components/StackLink";
+export { default as StackLinkProvider } from "./provider";
+export { isInStackFrame } from "./utils";

--- a/src/service/StackLink/provider/index.tsx
+++ b/src/service/StackLink/provider/index.tsx
@@ -19,6 +19,10 @@ export default function StackLinkProvider({ children }: PropsWithChildren) {
 
   useEffect(() => {
     const element = document.getElementById("stack-root");
+    if (!element) {
+      console.error("[StackLinkProvider] stack-root element not found");
+    }
+
     setPortalElement(element);
   }, []);
 

--- a/src/service/StackLink/provider/index.tsx
+++ b/src/service/StackLink/provider/index.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { PropsWithChildren, useCallback, useEffect, useState } from "react";
+
+import StackContext from "../context/stackContext";
+import type { PathTuple } from "../types";
+
+export default function StackLinkProvider({ children }: PropsWithChildren) {
+  const [history, setHistory] = useState<PathTuple[]>([]);
+  const [portalElement, setPortalElement] = useState<HTMLElement | null>(null);
+
+  const push = useCallback((pathTuple: PathTuple) => {
+    setHistory((prev) => [...prev, pathTuple]);
+  }, []);
+
+  const pop = useCallback(() => {
+    setHistory((prev) => prev.slice(0, -1));
+  }, []);
+
+  useEffect(() => {
+    const element = document.getElementById("stack-root");
+    setPortalElement(element);
+  }, []);
+
+  return (
+    <StackContext.Provider value={{ portalElement, history, push, pop }}>
+      <div id="stack-main" className="relative bg-white transform-gpu">
+        {children}
+      </div>
+      <div id="stack-root" />
+    </StackContext.Provider>
+  );
+}

--- a/src/service/StackLink/types/index.ts
+++ b/src/service/StackLink/types/index.ts
@@ -1,0 +1,8 @@
+export type PathTuple = [string, string];
+
+export interface StackContextType {
+  portalElement: HTMLElement | null;
+  history: PathTuple[];
+  push: (path: PathTuple) => void;
+  pop: () => void;
+}

--- a/src/service/StackLink/utils/index.ts
+++ b/src/service/StackLink/utils/index.ts
@@ -1,0 +1,8 @@
+export const isInStackFrame = () => {
+  try {
+    return window.self !== window.top;
+  } catch (e) {
+    console.error("[isInIframe] Error checking if in iframe:", e);
+    return true;
+  }
+};


### PR DESCRIPTION
### 개요

close #58 

### 작업사항

웹에서 앱과 유사한 화면 전환을 할 수 있는 Stack Link 라이브러리를 구현하였습니다. 

<div align="center">
<img width="40%" src="https://github.com/user-attachments/assets/d58ba5a7-1dab-4ba4-ba04-7beb6ad9e15a"/>
</div>

현재는 next.js의  app 디렉토리에서 사용할 수 있으며, 아이폰의 뒤로가기만 지원합니다. 
클라이언트 렌더링 및 서버 사이드 렌더링 모두 지원합니다.

전체적인 동작 원리는 아래와 같습니다. 

- 사용하기 전 provider로 <StackLink/>를 사용할 범위를 감쌉니다. 이때 전체적인 화면의 구성은 아래와 같습니다. 

<div align="center">
<img width="25%" src="https://github.com/user-attachments/assets/ab06ad9d-8beb-4db5-a281-5f3500aad5e5" />
</div>

- <StackLink/> 컴포넌트를 감싸서 링크 기능을 사용할수 있습니다. 이때 이동할 href를 props로 받습니다. 
- <StackLink/> 컴포넌트는 받은 href를 사이드에 iframe를 통해서 미리 띄워둡니다. 해당 컴포넌트를 stack frame이라고 부릅니다. 이 시간동안 next.js의 /app에서 사용 가능한 `router.prefetch`를 통해 `router.push()`로 바로 이동할 수 있도록 합니다. 
- <StackLink/> 컴포넌트를 클릭하면 stack frame이 오른쪽에서 왼쪽으로 오면서 화면을 가립니다. 이동 시간은 duration props로 받으며, 이 시간동안 이동합니다.
- dutation이후 `router.push()`로 페이지를 이동합니다.

아래는 이 동작에 대한 다이어그램입니다

<div align="center">
<img width="982" height="389" alt="image" src="https://github.com/user-attachments/assets/20459a17-0520-4fe5-9f40-02f6d88b4348" />
</div>


관련된 사용 방법 및 상세 동작 원리, 구현 방법은 따로 문서화를 하도록 하겠습니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * StackLink 기반의 슬라이딩 전환 내비게이션이 도입되어, 코스 및 산 리스트에서 부드러운 페이지 전환이 가능합니다.
  * 터치 기기에서 스와이프 제스처로 뒤로 가기 기능이 추가되었습니다.
  * 코스 리스트가 없을 경우 "코스가 없습니다." 메시지가 표시됩니다.
  * Iframe 컴포넌트 및 StackLinkProvider가 추가되어 내비게이션 상태 관리를 지원합니다.

* **버그 수정**
  * 버튼 역할 속성이 올바르게 적용되어 접근성이 개선되었습니다.

* **기타**
  * 개발 환경에서 특정 헤더가 조건부로 적용되도록 API 설정이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->