### PR TITLE
fix: env path를 가져오지 못해 발생하는 빌드 에러 수정

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -5,7 +5,9 @@ const nextConfig: NextConfig = {
   output: "standalone",
   devIndicators: false,
   images: {
-    remotePatterns: [new URL(`${process.env.IMAGE_REMOTE_URL}`)],
+    remotePatterns: process.env.IMAGE_REMOTE_URL
+      ? [new URL(process.env.IMAGE_REMOTE_URL)]
+      : [],
   },
 };
 


### PR DESCRIPTION

close#66

### 개요

close #66 

### 작업사항

next.config.ts에서 images주소를 env에서 관리하는데, 빌드 타임에 이를 가져오지 못하는 경우 빌드 자체가 되지 않는 문제가 발생하였습니다.
이를 조건부로 빈 배열을 주도록 하여 빌드 에러가 나지 않도록 수정하였습니다. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 환경 변수 미설정 시 이미지 로드 오류를 방지하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->