### PR TITLE
fix: env 파일을 생성, 사용하도록 수정

### DIFF
--- a/.github/workflows/front-dev.yml
+++ b/.github/workflows/front-dev.yml
@@ -51,6 +51,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-        
 
+      - name: Create .env file
+        run: |
+          echo "NEXT_PUBLIC_API_URL=${{ secrets.NEXT_PUBLIC_API_URL }}" > .env
+          echo "NEXT_PUBLIC_NAVER_KEY=${{ secrets.NEXT_PUBLIC_NAVER_KEY }}" >> .env
+          echo "NEXT_PUBLIC_NAVER_SECRET=${{ secrets.NEXT_PUBLIC_NAVER_SECRET }}" >>
+
       - name: Build, tag, and push image to Amazon ECR
         id: build-image
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@
 FROM node:20-alpine AS builder
 WORKDIR /app
 
+COPY .env .env
 RUN npm install -g pnpm
 COPY package.json pnpm-lock.yaml ./
 


### PR DESCRIPTION
### 개요

close #70 

### 작업사항

- github action build 단계에서 .env 파일 생성하도록 추가
- 도커파일에서 .env 파일을 복사해오도록 추가 
  -> 도커 빌드 시에 .env파일을 올바르게 참조가 가능합니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * GitHub Actions 워크플로우에 `.env` 파일을 자동 생성하는 단계가 추가되었습니다.
  * Docker 이미지 빌드 시 `.env` 파일이 컨테이너에 복사되도록 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->