### PR TITLE
fix: dockerignore파일에서 env 관련 내용 제거

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,10 +6,6 @@ node_modules
 dist
 out
 
-# (env들은 필요할 수도?)
-.env
-.env.*
-
 .DS_Store
 .vscode
 .idea


### PR DESCRIPTION
### 개요

close #72 

### 작업사항

- dockerignore파일에서 env 관련 내용을 제거했습니다.

### 변경로직

- 도커에서 올바르게 env 파일을 불러올 수 있게 됩니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Docker 빌드 컨텍스트에서 `.env` 및 `.env.*` 파일 제외 설정이 제거되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->