### PR TITLE
fix: 빌드에서 prerendering error 가 발생하는 부분을 빌드에서 제외하도록 수정

### DIFF
--- a/src/app/check-position/page.tsx
+++ b/src/app/check-position/page.tsx
@@ -1,10 +1,5 @@
 import CheckPositionMap from "@pages/check-position/CheckPositionMap";
-import { Suspense } from "@suspensive/react";
 
 export default function CheckPositionPage() {
-  return (
-    <Suspense>
-      <CheckPositionMap />
-    </Suspense>
-  );
+  return <CheckPositionMap />;
 }

--- a/src/components/common/shared/ui/Spinner/index.tsx
+++ b/src/components/common/shared/ui/Spinner/index.tsx
@@ -3,14 +3,14 @@ import { cva, VariantProps } from "class-variance-authority";
 import { cn } from "@/utils/cn";
 
 export const SpinnerVariants = cva(
-  `rounded-full border-4 border-t-transparent animate-spin`,
+  `rounded-full border-t-transparent animate-spin`,
   {
     variants: {
       size: {
-        sm: "w-4 h-4",
-        md: "w-8 h-8",
-        lg: "w-12 h-12",
-        xl: "w-16 h-16",
+        sm: "w-4 h-4 border-2",
+        md: "w-8 h-8 border-3",
+        lg: "w-12 h-12 border-4",
+        xl: "w-16 h-16 border-4",
       },
     },
     defaultVariants: {

--- a/src/components/features/pages/check-position/CheckPositionMap/index.tsx
+++ b/src/components/features/pages/check-position/CheckPositionMap/index.tsx
@@ -6,8 +6,11 @@ import useNaverMap from "@hooks/feature/map/useNaverMap";
 import PositionBottom from "@shared/layout/PositionBottom/index";
 import Spacing from "@shared/layout/Spacing";
 import Button from "@shared/ui/Button";
+import { Suspense } from "@suspensive/react";
 import { useSearchParams } from "next/navigation";
 import { useEffect } from "react";
+
+import CheckPositionMapLoader from "./loader";
 
 const DEFAULT_POSITION = { latitude: 35.122769, longitude: 126.996822 };
 
@@ -17,94 +20,101 @@ interface CheckPositionMapProps {
 }
 
 //TODO: 지도와 버튼/기능을 분리하기
-export default function CheckPositionMap({
-  defaultPosition = DEFAULT_POSITION,
-  zoom = 18,
-}: CheckPositionMapProps) {
-  const searchParams = useSearchParams();
-  const latitude = searchParams.get("lat");
-  const longitude = searchParams.get("lng");
+export default Suspense.with(
+  {
+    fallback: <CheckPositionMapLoader />,
+    clientOnly: true,
+    name: "CheckPositionMap",
+  },
+  function CheckPositionMap({
+    defaultPosition = DEFAULT_POSITION,
+    zoom = 18,
+  }: CheckPositionMapProps) {
+    const searchParams = useSearchParams();
+    const latitude = searchParams.get("lat");
+    const longitude = searchParams.get("lng");
 
-  const initialPosition = {
-    latitude: latitude ? parseFloat(latitude) : defaultPosition.latitude,
-    longitude: longitude ? parseFloat(longitude) : defaultPosition.longitude,
-  };
+    const initialPosition = {
+      latitude: latitude ? parseFloat(latitude) : defaultPosition.latitude,
+      longitude: longitude ? parseFloat(longitude) : defaultPosition.longitude,
+    };
 
-  const goBack = useRouteBackBridge();
-  const setReportPosition = useSetReportPositionBridge();
-  // const getCurrentPosition = useGetCurrentPositionBridge();
+    const goBack = useRouteBackBridge();
+    const setReportPosition = useSetReportPositionBridge();
+    // const getCurrentPosition = useGetCurrentPositionBridge();
 
-  const { mapId, map } = useNaverMap({
-    latitude: initialPosition.latitude,
-    longitude: initialPosition.longitude,
-    zoom,
-  });
-
-  useEffect(() => {
-    if (!map) return;
-
-    const listener = naver.maps.Event.addListener(map, "dragend", () => {
-      const center = map.getCenter();
-      const position = {
-        latitude: center.lat(),
-        longitude: center.lng(),
-      };
-      setReportPosition(position);
-      // getCurrentPosition(position);
+    const { mapId, map } = useNaverMap({
+      latitude: initialPosition.latitude,
+      longitude: initialPosition.longitude,
+      zoom,
     });
 
-    return () => {
-      naver.maps.Event.removeListener(listener);
+    useEffect(() => {
+      if (!map) return;
+
+      const listener = naver.maps.Event.addListener(map, "dragend", () => {
+        const center = map.getCenter();
+        const position = {
+          latitude: center.lat(),
+          longitude: center.lng(),
+        };
+        setReportPosition(position);
+        // getCurrentPosition(position);
+      });
+
+      return () => {
+        naver.maps.Event.removeListener(listener);
+      };
+    }, [map, setReportPosition]);
+
+    const handleCurrentPositionClick = () => {
+      // initialPosition로 이동
+      // if (map) {
+      //   map.setCenter(
+      //     new naver.maps.LatLng(
+      //       initialPosition.latitude,
+      //       initialPosition.longitude
+      //     )
+      //   );
+      //   setReportPosition(initialPosition);
+      // }
+      goBack();
     };
-  }, [map, setReportPosition]);
 
-  const handleCurrentPositionClick = () => {
-    // initialPosition로 이동
-    // if (map) {
-    //   map.setCenter(
-    //     new naver.maps.LatLng(
-    //       initialPosition.latitude,
-    //       initialPosition.longitude
-    //     )
-    //   );
-    //   setReportPosition(initialPosition);
-    // }
-    goBack();
-  };
-
-  return (
-    <div className="relative h-screen w-screen">
-      <div id={mapId} className="h-full w-full" />
-      <div className="absolute left-1/2 top-1/2 z-10 h-8 w-8 -translate-x-1/2 -translate-y-1/2 transform pointer-events-none">
-        <div className="h-full w-full rounded-full border-4 border-red-500 bg-red-500 shadow-lg">
-          <div className="absolute left-1/2 top-1/2 h-3 w-3 -translate-x-1/2 -translate-y-1/2 transform rounded-full bg-white"></div>
+    return (
+      <div className="relative h-screen w-screen">
+        <div id={mapId} className="h-full w-full" />
+        <div className="absolute left-1/2 top-1/2 z-10 h-8 w-8 -translate-x-1/2 -translate-y-1/2 transform pointer-events-none">
+          <div className="h-full w-full rounded-full border-4 border-red-500 bg-red-500 shadow-lg">
+            <div className="absolute left-1/2 top-1/2 h-3 w-3 -translate-x-1/2 -translate-y-1/2 transform rounded-full bg-white"></div>
+          </div>
         </div>
+        <PositionBottom padding={6}>
+          <Button fullWidth onClick={handleCurrentPositionClick}>
+            현재 위치로 설정
+          </Button>
+          <Spacing size={4} />
+          <Button
+            fullWidth
+            color={"white"}
+            onClick={() => {
+              // initialPosition로 이동
+              if (map) {
+                map.setCenter(
+                  new naver.maps.LatLng(
+                    initialPosition.latitude,
+                    initialPosition.longitude
+                  )
+                );
+                setReportPosition(initialPosition);
+              }
+              goBack();
+            }}
+          >
+            취소
+          </Button>
+        </PositionBottom>
       </div>
-      <PositionBottom padding={6}>
-        <Button fullWidth onClick={handleCurrentPositionClick}>
-          현재 위치로 설정
-        </Button>
-        <Spacing size={4} />
-        <Button
-          fullWidth
-          color={"white"}
-          onClick={() => {
-            // initialPosition로 이동
-            if (map) {
-              map.setCenter(
-                new naver.maps.LatLng(
-                  initialPosition.latitude,
-                  initialPosition.longitude
-                )
-              );
-              setReportPosition(initialPosition);
-            }
-            goBack();
-          }}
-        >
-          취소
-        </Button>
-      </PositionBottom>
-    </div>
-  );
-}
+    );
+  }
+);

--- a/src/components/features/pages/check-position/CheckPositionMap/loader.tsx
+++ b/src/components/features/pages/check-position/CheckPositionMap/loader.tsx
@@ -1,0 +1,10 @@
+export default function CheckPositionMapLoader() {
+  return (
+    <div>
+      <div className="w-screen h-screen flex items-center justify-center">
+        <div className="animate-spin rounded-full border-b-2 border-r-2 border-main-green" />
+        <span className="ml-4 text-gray-20 text-xl">지도 불러오는 중...</span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/features/pages/course/CourseTabBarSection/index.tsx
+++ b/src/components/features/pages/course/CourseTabBarSection/index.tsx
@@ -9,7 +9,9 @@ import Spacing from "@shared/layout/Spacing";
 import { Suspense } from "@suspensive/react";
 import CourseListWithBookmarkMutate from "@widgets/course/CourseListWithBookmarkMutate";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
-import CourseTabBarSectionSkeleton from "./CourseTabBarSection.skeleton";
+
+//inner imports
+import CourseTabBarSectionLoader from "./loader";
 
 const tabTitleList = [
   { title: "내 맞춤형", sort: "my" },
@@ -22,7 +24,7 @@ export default Suspense.with(
   {
     name: "CourseTabSection",
     clientOnly: true,
-    fallback: <CourseTabBarSectionSkeleton />,
+    fallback: <CourseTabBarSectionLoader />,
   },
   function CourseTabSection() {
     const router = useRouter();

--- a/src/components/features/pages/course/CourseTabBarSection/loader.tsx
+++ b/src/components/features/pages/course/CourseTabBarSection/loader.tsx
@@ -1,6 +1,6 @@
 import Spacing from "@shared/layout/Spacing";
 
-export default function CourseTabBarSectionSkeleton() {
+export default function CourseTabBarSectionLoader() {
   return (
     <section className="flex flex-col flex-1 overflow-hidden">
       {/* Tab Bar Skeleton */}

--- a/src/components/features/pages/login/KakaoLoginSection/error.tsx
+++ b/src/components/features/pages/login/KakaoLoginSection/error.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import useRouteBackBridge from "@hooks/feature/bridge/useRouteBackBridge";
+import useShowToastBridge from "@hooks/feature/bridge/useShowToastBridge";
+
+export default function ErrorFallback() {
+  const goBack = useRouteBackBridge();
+  const showToast = useShowToastBridge();
+  showToast({
+    type: "error",
+    text1: "카카오 로그인 실패",
+    text2: "로그인에 실패했습니다. 잠시 후 다시 시도해주세요.",
+  });
+  goBack();
+  return (
+    <div className="w-screen h-screen flex items-center justify-center">
+      <span className="ml-4 text-gray-700 text-2xl">
+        로그인에 실패했습니다... 🥲
+      </span>
+    </div>
+  );
+}

--- a/src/components/features/pages/login/KakaoLoginSection/index.tsx
+++ b/src/components/features/pages/login/KakaoLoginSection/index.tsx
@@ -1,54 +1,30 @@
 "use client";
 
-import useRouteBackBridge from "@hooks/feature/bridge/useRouteBackBridge";
-import useShowToastBridge from "@hooks/feature/bridge/useShowToastBridge";
 import useKakaoLoginQuery from "@hooks/feature/query/query/useKakaoLoginQuery";
-import Spinner from "@shared/ui/Spinner";
 import { ErrorBoundary, Suspense } from "@suspensive/react";
+
+import ErrorFallback from "./error";
+import KakaoLoginSectionLoader from "./loader";
 
 export default ErrorBoundary.with(
   {
-    onError: function ErrorHandler() {
-      const goBack = useRouteBackBridge();
-      const showToast = useShowToastBridge();
-      showToast({
-        type: "error",
-        text1: "카카오 로그인 실패",
-        text2: "로그인에 실패했습니다. 잠시 후 다시 시도해주세요.",
-      });
-      goBack();
-    },
-    fallback: function ErrorFallback() {
-      return (
-        <div className="w-screen h-screen flex items-center justify-center">
-          <span className="ml-4 text-gray-700 text-2xl">
-            로그인에 실패했습니다... 🥲
-          </span>
-        </div>
-      );
-    },
+    fallback: <ErrorFallback />,
   },
   Suspense.with(
     {
-      fallback: (
-        <div className="w-screen h-screen flex items-center justify-center">
-          <div className="animate-spin rounded-full border-b-2 border-r-2 border-main-green" />
-          <Spinner size={"sm"} />
-          <span className="ml-4 text-gray-20 text-xl">
-            카카오 로그인 페이지로 이동중...
-          </span>
-        </div>
-      ),
+      fallback: <KakaoLoginSectionLoader />,
       clientOnly: true,
       name: "KakaoLoginSection",
     },
     () => {
       const { data } = useKakaoLoginQuery();
-      if (data && data.uri) {
+
+      if ((data && data.uri) || typeof window !== "undefined") {
         const { uri } = data;
         window.location.href = uri;
         return null;
       }
+
       return null;
     }
   )

--- a/src/components/features/pages/login/KakaoLoginSection/index.tsx
+++ b/src/components/features/pages/login/KakaoLoginSection/index.tsx
@@ -1,44 +1,55 @@
 "use client";
 
-import useRouteBackBridge from "@/hooks/feature/bridge/useRouteBackBridge";
-import useShowToastBridge from "@/hooks/feature/bridge/useShowToastBridge";
-import useKakaoLoginQuery from "@/hooks/feature/query/query/useKakaoLoginQuery";
-// import { useRouter } from "next/navigation";
+import useRouteBackBridge from "@hooks/feature/bridge/useRouteBackBridge";
+import useShowToastBridge from "@hooks/feature/bridge/useShowToastBridge";
+import useKakaoLoginQuery from "@hooks/feature/query/query/useKakaoLoginQuery";
+import Spinner from "@shared/ui/Spinner";
+import { ErrorBoundary, Suspense } from "@suspensive/react";
 
-export default function KakaoLoginSection() {
-  const { data, isLoading, error } = useKakaoLoginQuery();
-  // const route = useRouter();
-  const goBack = useRouteBackBridge();
-  const showToast = useShowToastBridge();
-
-  if (error) {
-    showToast({
-      type: "error",
-      text1: "카카오 로그인 실패",
-      text2: "로그인에 실패했습니다. 잠시 후 다시 시도해주세요.",
-    });
-    // alert("카카오 로그인에 실패했습니다. 잠시 후 다시 시도해주세요.");
-    goBack();
-    return (
-      <div className="w-screen h-screen flex items-center justify-center">
-        <span className="ml-4 text-gray-700 text-2xl">
-          로그인에 실패했습니다... 🥲
-        </span>
-      </div>
-    );
-  }
-
-  if (!isLoading && data && data.uri) {
-    const { uri } = data;
-    // alert(uri);
-    window.location.href = uri;
-    return null;
-  }
-
-  return (
-    <div className="w-screen h-screen flex items-center justify-center">
-      <div className="animate-spin rounded-full border-b-2 border-r-2 border-main-green" />
-      <span className="ml-4 text-gray-700 text-2xl">로그인 중...</span>
-    </div>
-  );
-}
+export default ErrorBoundary.with(
+  {
+    onError: function ErrorHandler() {
+      const goBack = useRouteBackBridge();
+      const showToast = useShowToastBridge();
+      showToast({
+        type: "error",
+        text1: "카카오 로그인 실패",
+        text2: "로그인에 실패했습니다. 잠시 후 다시 시도해주세요.",
+      });
+      goBack();
+    },
+    fallback: function ErrorFallback() {
+      return (
+        <div className="w-screen h-screen flex items-center justify-center">
+          <span className="ml-4 text-gray-700 text-2xl">
+            로그인에 실패했습니다... 🥲
+          </span>
+        </div>
+      );
+    },
+  },
+  Suspense.with(
+    {
+      fallback: (
+        <div className="w-screen h-screen flex items-center justify-center">
+          <div className="animate-spin rounded-full border-b-2 border-r-2 border-main-green" />
+          <Spinner size={"sm"} />
+          <span className="ml-4 text-gray-20 text-xl">
+            카카오 로그인 페이지로 이동중...
+          </span>
+        </div>
+      ),
+      clientOnly: true,
+      name: "KakaoLoginSection",
+    },
+    () => {
+      const { data } = useKakaoLoginQuery();
+      if (data && data.uri) {
+        const { uri } = data;
+        window.location.href = uri;
+        return null;
+      }
+      return null;
+    }
+  )
+);

--- a/src/components/features/pages/login/KakaoLoginSection/loader.tsx
+++ b/src/components/features/pages/login/KakaoLoginSection/loader.tsx
@@ -1,0 +1,13 @@
+import Spinner from "@shared/ui/Spinner";
+
+export default function KakaoLoginSectionLoader() {
+  return (
+    <div className="w-screen h-screen flex items-center justify-center">
+      <div className="animate-spin rounded-full border-b-2 border-r-2 border-main-green" />
+      <Spinner size={"sm"} />
+      <span className="ml-4 text-gray-20 text-xl">
+        카카오 로그인 페이지로 이동중...
+      </span>
+    </div>
+  );
+}

--- a/src/hooks/feature/query/query/useKakaoLoginQuery/index.tsx
+++ b/src/hooks/feature/query/query/useKakaoLoginQuery/index.tsx
@@ -1,8 +1,8 @@
 import { getKakaoLoginApi, KAKAO_LOGIN_URI } from "@api/v1/oauth/kakao";
-import { useQuery } from "@tanstack/react-query";
+import { useSuspenseQuery } from "@tanstack/react-query";
 
 const useKakaoLoginQuery = () => {
-  return useQuery({
+  return useSuspenseQuery({
     queryKey: [KAKAO_LOGIN_URI],
     queryFn: getKakaoLoginApi,
   });


### PR DESCRIPTION
### 개요

close #issueNumber

### 작업사항

빌드에서 에러가 나던 check-position 페이지와 login 페이지를 suspensive의 client only 속성을 주어 빌드타임에서 코드가 실행되지 않도록 하였습니다

머지 후에도 해당 에러가 발생한다면 추가 작업 후 pr 날리도록 하겠습니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 카카오 로그인 실패 시 에러 메시지와 함께 이전 페이지로 자동 이동하는 에러 처리 화면이 추가되었습니다.
  * 지도 위치 확인 페이지에 "취소" 버튼이 추가되어, 초기 위치로 재설정 후 이전 페이지로 돌아갈 수 있습니다.
  * 지도 및 카카오 로그인 진행 시 전용 로딩 화면이 추가되었습니다.

* **버그 수정**
  * 스피너(Spinner) 컴포넌트의 크기에 따라 테두리 두께가 다르게 적용되어 시각적 일관성이 향상되었습니다.

* **리팩터**
  * 지도 위치 확인 및 카카오 로그인 페이지의 로딩/에러 처리가 Suspense 및 ErrorBoundary 기반으로 개선되어 사용자 경험이 향상되었습니다.
  * 코스 탭바 섹션의 로딩 컴포넌트 명칭이 일관성 있게 변경되었습니다.

* **기타**
  * 카카오 로그인 쿼리 훅이 Suspense 기반으로 동작하도록 내부 구현이 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->