### PR TITLE
fix: 앱이 아닌 웹 환경에서 올바르게 navigation을 가져오지 못하는 경우에 대한 예외 처리

### DIFF
--- a/src/service/bridge/components/BridgeRequestListener/index.tsx
+++ b/src/service/bridge/components/BridgeRequestListener/index.tsx
@@ -102,7 +102,7 @@ export default function BridgeRequestListener<RequestType, ResponseType>({
     };
 
     // 요청에 대한 응답을 처리하는 로직
-    if (Message.isAndroid) {
+    if (Message.checkIsAndroid()) {
       document.addEventListener("message", handleMessage as EventListener);
       return () =>
         document.removeEventListener("message", handleMessage as EventListener);

--- a/src/service/bridge/core/Message.ts
+++ b/src/service/bridge/core/Message.ts
@@ -9,7 +9,10 @@ class Message<Body> implements WebviewBridgeMessage<Body> {
 
   private R_WND: RWindow;
 
-  public static isAndroid = /Android/i.test(navigator.userAgent);
+  public static checkIsAndroid = () => {
+    if (!window || !navigator) return false;
+    return /Android/i.test(navigator.userAgent);
+  };
 
   constructor(
     rwnd: RWindow,
@@ -65,19 +68,14 @@ class Message<Body> implements WebviewBridgeMessage<Body> {
       if (resMessage.ack === this._id) {
         const listeners = this.R_WND.popCallbacksById(this._id);
         listeners.forEach((listener) => listener(resMessage));
-        if (Message.isAndroid) {
-          document.removeEventListener("message", messageHandler);
-        } else {
-          window.removeEventListener("message", messageHandler);
-        }
+
+        document.removeEventListener("message", messageHandler);
+        window.removeEventListener("message", messageHandler);
       }
     };
 
-    if (Message.isAndroid) {
-      document.addEventListener("message", messageHandler as EventListener);
-    } else {
-      window.addEventListener("message", messageHandler);
-    }
+    document.addEventListener("message", messageHandler as EventListener);
+    window.addEventListener("message", messageHandler);
   };
 }
 


### PR DESCRIPTION
### 개요
#80 

### 작업사항

기존에 앱이 아닌 환경에서 올바르게 기종을 판단하지 못하는 에러를 수정하였습니다. 
안드로이드인지를 확인하기 위해서 navigator에 접근하는데, 해당 코드를 웹 및 서버에서 사용하지 못하도록 수정하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * Android 환경 감지 방식이 개선되어 더 안정적으로 동작합니다.
  * 메시지 이벤트 리스너가 항상 모든 환경에서 정상적으로 등록 및 해제됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->