### PR TITLE
feat: axios instance에서 response error가 발생한 경우, 이를 형식에 맞추어 포매팅할 수 있는 로직 추가

### DIFF
--- a/src/api/_instances/authenticatedApi/index.ts
+++ b/src/api/_instances/authenticatedApi/index.ts
@@ -1,5 +1,6 @@
 import { isInStackFrame } from "@/service/StackLink";
-import axios, { AxiosResponse } from "axios";
+import { ErrorResponse } from "@/types/api";
+import axios, { AxiosError, AxiosResponse } from "axios";
 
 const authenticatedApi = axios.create({
   baseURL: process.env.NEXT_PUBLIC_BASE_URL?.replace(/\/$/, ""),
@@ -43,8 +44,14 @@ authenticatedApi.interceptors.response.use(
   (response: AxiosResponse) => {
     return response.data;
   },
-  async (error) => {
-    return Promise.reject(error);
+  async (error: AxiosError<ErrorResponse>) => {
+    const apiError: ErrorResponse = {
+      status: "error",
+      errorCode: error.response?.data.errorCode || "UNKNOWN_ERROR",
+      message:
+        error.response?.data?.message || "알 수 없는 오류가 발생했습니다.",
+    };
+    return Promise.reject(apiError);
   }
 );
 

--- a/src/api/_instances/authenticatedApi/index.ts
+++ b/src/api/_instances/authenticatedApi/index.ts
@@ -44,14 +44,24 @@ authenticatedApi.interceptors.response.use(
   (response: AxiosResponse) => {
     return response.data;
   },
+
   async (error: AxiosError<ErrorResponse>) => {
-    const apiError: ErrorResponse = {
-      status: "error",
-      errorCode: error.response?.data.errorCode || "UNKNOWN_ERROR",
-      message:
-        error.response?.data?.message || "알 수 없는 오류가 발생했습니다.",
-    };
-    return Promise.reject(apiError);
+    const err = Object.assign(
+      new Error(
+        error.response?.data?.message || "알 수 없는 오류가 발생했습니다."
+      ),
+      {
+        name: "ApiError",
+        status: "error" as const,
+        errorCode: error.response?.data?.errorCode ?? "UNKNOWN_ERROR",
+        httpStatus: error.response?.status,
+        url: error.config?.url,
+        cause: error,
+      }
+    ) as Error &
+      ErrorResponse & { httpStatus?: number; url?: string; cause?: unknown };
+
+    return Promise.reject(err);
   }
 );
 

--- a/src/api/_instances/publicApi/index.ts
+++ b/src/api/_instances/publicApi/index.ts
@@ -1,4 +1,5 @@
-import axios, { AxiosResponse } from "axios";
+import { ErrorResponse } from "@/types/api";
+import axios, { AxiosError, AxiosResponse } from "axios";
 
 const publicApi = axios.create({
   baseURL: `${process.env.NEXT_PUBLIC_BASE_URL}`?.replace(/\/$/, ""),
@@ -20,8 +21,14 @@ publicApi.interceptors.response.use(
   (response: AxiosResponse) => {
     return response.data;
   },
-  async (error) => {
-    return Promise.reject(error);
+  async (error: AxiosError<ErrorResponse>) => {
+    const apiError: ErrorResponse = {
+      status: "error",
+      errorCode: error.response?.data.errorCode || "UNKNOWN_ERROR",
+      message:
+        error.response?.data?.message || "알 수 없는 오류가 발생했습니다.",
+    };
+    return Promise.reject(apiError);
   }
 );
 

--- a/src/api/_instances/publicApi/index.ts
+++ b/src/api/_instances/publicApi/index.ts
@@ -22,13 +22,22 @@ publicApi.interceptors.response.use(
     return response.data;
   },
   async (error: AxiosError<ErrorResponse>) => {
-    const apiError: ErrorResponse = {
-      status: "error",
-      errorCode: error.response?.data.errorCode || "UNKNOWN_ERROR",
-      message:
-        error.response?.data?.message || "알 수 없는 오류가 발생했습니다.",
-    };
-    return Promise.reject(apiError);
+    const err = Object.assign(
+      new Error(
+        error.response?.data?.message || "알 수 없는 오류가 발생했습니다."
+      ),
+      {
+        name: "ApiError",
+        status: "error" as const,
+        errorCode: error.response?.data?.errorCode ?? "UNKNOWN_ERROR",
+        httpStatus: error.response?.status,
+        url: error.config?.url,
+        cause: error,
+      }
+    ) as Error &
+      ErrorResponse & { httpStatus?: number; url?: string; cause?: unknown };
+
+    return Promise.reject(err);
   }
 );
 

--- a/src/types/api/index.ts
+++ b/src/types/api/index.ts
@@ -1,0 +1,5 @@
+export interface ErrorResponse {
+  status: "error";
+  errorCode: string;
+  message: string;
+}


### PR DESCRIPTION
### 개요

close ##85

### 작업사항

axios instance에서 reponse error가 발생한 경우, 이를 형식에 맞추어 포매팅할 수 있는 로직을 추가하였습니다.
앞으로 api 관련 에러 핸들링을 하는 위치에서는 에러 타입을 추론할 수 있게 됩니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 인증/공용 API 요청 실패 시 더 구체적인 오류 메시지와 코드, HTTP 상태, 요청 URL을 제공하여 오류 내용을 쉽게 파악할 수 있습니다.
  - 서버 응답이 없거나 메시지가 비어도 한국어 기본 메시지(“알 수 없는 오류가 발생했습니다.”)를 표시해 가독성을 높였습니다.
  - 앱 전반에서 오류 응답 형식을 표준화해 일관된 알림/표시가 가능합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->